### PR TITLE
Fix for No podspec found error after plugin rename

### DIFF
--- a/CapacitorCommunityCameraPreview.podspec
+++ b/CapacitorCommunityCameraPreview.podspec
@@ -1,6 +1,6 @@
 
   Pod::Spec.new do |s|
-    s.name = 'CapacitorCameraPreview'
+    s.name = 'CapacitorCommunityCameraPreview'
     s.version = '0.0.1'
     s.summary = 'Camera preview'
     s.license = 'MIT'


### PR DESCRIPTION
This should fix this issue https://github.com/capacitor-community/camera-preview/issues/37