### PR TITLE
Fix for CapacitorCommunityCameraPreview.podspec not included into npm package published

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dist/",
     "ios/",
     "android/",
-    "CapacitorCameraPreview.podspec"
+    "CapacitorCommunityCameraPreview.podspec"
   ],
   "keywords": [
     "capacitor",


### PR DESCRIPTION
package.json files referenced the previous file name so the new renamed file was not included into the published npm package.