### PR TITLE
Fix definitions

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -35,4 +35,5 @@ export interface CameraPreviewPlugin {
     result: CameraPreviewFlashMode[]
   }>;
   setFlashMode(options: { flashMode: CameraPreviewFlashMode | string }): void;
+  flip(): void;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -90,6 +90,9 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
     throw new Error('setFlashMode not supported under the web platform');
   }
 
+  async flip(): Promise<void> {
+    throw new Error('flip not supported under the web platform');
+  }
 }
 
 const CameraPreview = new CameraPreviewWeb();


### PR DESCRIPTION
Hi, I added definitions for flip() method in CameraPreview interface. Also I added a default stub implementation for that method in the web platform (actually throws an error like other not supported methods).