### PR TITLE
fix(CameraPreviewWeb): remove video element from parent

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -47,18 +47,18 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
 
   async stop(): Promise<any> {
     const video = <HTMLVideoElement>document.getElementById("video");
+    if (video) {
+      video.pause();
 
-    video.pause();
+      const st: any = video.srcObject;
+      const tracks = st.getTracks();
 
-    const st: any = video.srcObject;
-    const tracks = st.getTracks();
-
-    for (var i = 0; i < tracks.length; i++) {
-      var track = tracks[i];
-      track.stop();
+      for (var i = 0; i < tracks.length; i++) {
+        var track = tracks[i];
+        track.stop();
+      }
+      video.remove();
     }
-
-    video.srcObject = null;
   }
 
   async capture(_options: CameraPreviewPictureOptions): Promise<any> {


### PR DESCRIPTION
Hi, Since`start()` looks for a video element and if it doesn't exists. It creates a video element, else throws `camera already started`.

While restarting the camera since `stop()` doesn't remove the element. It was throwing the same.

I fixed this, so the video element is now removed properly in `stop()`.