### PR TITLE
fix: add origin (x,y) to startCamera

### DIFF
--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -200,6 +200,8 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
             position = "front";
         }
 
+        final Integer x = call.getInt("x", 0);
+        final Integer y = call.getInt("y", 0);
         final Integer width = call.getInt("width", 0);
         final Integer height = call.getInt("height", 0);
         final Integer paddingBottom = call.getInt("paddingBottom", 0);
@@ -219,8 +221,8 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
             public void run() {
                 DisplayMetrics metrics = getBridge().getActivity().getResources().getDisplayMetrics();
                 // offset
-                int computedX = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX, 0, metrics);
-                int computedY = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX, 0, metrics);
+                int computedX = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, x, metrics);
+                int computedY = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, y, metrics);
 
                 // size
                 int computedWidth;
@@ -262,7 +264,6 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
 
                     getBridge().getWebView().setBackgroundColor(Color.TRANSPARENT);
                     ((ViewGroup)getBridge().getWebView().getParent()).addView(containerView);
-                    getBridge().getWebView().getParent().bringChildToFront(getBridge().getWebView());
 
 
                     FragmentManager fragmentManager = getBridge().getActivity().getFragmentManager();

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -14,6 +14,10 @@ export interface CameraPreviewOptions {
   width?: number;
   /** The preview height in pixels, default window.screen.height (applicable to the android and ios platforms only) */
   height?: number;
+  /** The x origin, default 0 (applicable to the android only) */
+  x?: number;
+  /** The y origin, default 0 (applicable to the android only) */
+  y?: number;
   /** The preview bottom padding in pixes. Useful to keep the appropriate preview sizes when orientation changes (applicable to the android and ios platforms only) */
   paddingBottom?: number;
   /** Rotate preview when orientation changes (applicable to the ios platforms only; default value is true) */


### PR DESCRIPTION
added origin (x, y) to startCamera for android. So now we can add the CameraPreview over a div or on specific place on the screen.

```
                    getBridge().getWebView().getParent().bringChildToFront(getBridge().getWebView());
```
Removed this line not sure what it does. But seems deprecated and hinders the preview for Ionic React.
