### PR TITLE
fix:image lateral inversion for webview and ios

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -129,8 +129,13 @@ public class CameraPreview: CAPPlugin {
                 call.reject(error.localizedDescription)
                 return
             }
-
-            let imageData = image.jpegData(compressionQuality: CGFloat(quality!))
+            let imageData: Data?
+            if (self.cameraPosition == "front") {
+                let flippedImage = image.withHorizontallyFlippedOrientation()
+                imageData = flippedImage.jpegData(compressionQuality: CGFloat(quality!))
+            } else {
+                imageData = image.jpegData(compressionQuality: CGFloat(quality!))
+            }
             let imageBase64 = imageData?.base64EncodedString()
             call.resolve(["value": imageBase64!])
         }

--- a/src/web.ts
+++ b/src/web.ts
@@ -71,6 +71,8 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
       const context = canvas.getContext("2d");
       canvas.width = video.videoWidth;
       canvas.height = video.videoHeight;
+      context.translate(video.videoWidth, 0);
+      context.scale(-1, 1);
       context.drawImage(video, 0, 0, video.videoWidth, video.videoHeight);
       resolve({
         value: canvas


### PR DESCRIPTION
laterally inverts image taken from webcam or front cam in iOS.
For android it's already there. Adding some consistency :wink: 