### PR TITLE
fix: add permission check and reject call

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -62,6 +62,13 @@ public class CameraPreview: CAPPlugin {
         if call.getInt("paddingBottom") != nil {
             self.paddingBottom = CGFloat(call.getInt("paddingBottom")!)
         }
+
+        AVCaptureDevice.requestAccess(for: .video, completionHandler: { (granted: Bool) in
+            if (!granted) {
+                call.reject("permission failed");
+            }
+        });
+
         self.rotateWhenOrientationChanged = call.getBool("rotateWhenOrientationChanged") ?? true
         self.toBack = call.getBool("toBack") ?? false
         if (self.rotateWhenOrientationChanged == true) {

--- a/src/web.ts
+++ b/src/web.ts
@@ -11,6 +11,12 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
 
   async start(options: CameraPreviewOptions): Promise<{}> {
     return new Promise((resolve, reject) => {
+      navigator.permissions.query({ name: "camera" }).then(res => {
+        if(res.state == "denied"){
+          reject({ message: "permission failed" });
+        }
+      });
+
       const video = document.getElementById("video");
       const parent = document.getElementById(options.parent);
 
@@ -40,7 +46,7 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
           );
         }
       } else {
-        reject("camera already started");
+        reject({ message: "camera already started" });
       }
     });
   }


### PR DESCRIPTION
If permission is not granted. There was no unified way to catch this and show a fallback UI.
Changes already exists for android. Needed this to be implemented for iOS and webview.

Now you can do 
```
await CameraPreview.start({
      ...
    }).catch(({ message }: { message: string }) => {
      if (message === 'permission failed') {
        // Show fallback ui or do something.
      }
    });
```