### PR TITLE
Ensure background of webview on iOS is transparent

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -88,6 +88,7 @@ public class CameraPreview: CAPPlugin {
                     self.previewView = UIView(frame: CGRect(x: self.x!, y: self.y!, width: self.width!, height: self.height!))
                     self.webView.isOpaque = false
                     self.webView.backgroundColor = UIColor.clear
+                    self.webView.scrollView.backgroundColor = UIColor.clear
                     self.webView.superview?.addSubview(self.previewView)
                     if (self.toBack!) {
                         self.webView.superview?.bringSubviewToFront(self.webView)


### PR DESCRIPTION
I found that when setting `toBack: true` in the `CameraPreviewOptions` the preview couldn't be seen. I suspected the elements within the webview were not transparent, but after setting all I could using CSS I was still unable to see the preview.

Searching the web I found that a line from solution 1 of [this article on izzi swift](https://izziswift.com/transparent-background-for-wkwebview/) where they suggest setting the `scrollView.backgroundColor` to transparent which worked! Finally the preview underneath the webview was visible! 🎉 

I believe this solves issue #53