### PR TITLE
Android Image Dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ CameraPreview.hide();
 | Option   | values        | descriptions                                                         |
 |----------|---------------|----------------------------------------------------------------------|
 | quality  | number        | (optional) The picture quality, 0 - 100, default 85                  |
+| width    | number        | (optional) The picture width, default 0 (Device default)             |
+| height   | number        | (optional) The picture height, default 0 (Device default)            |
 
 <!-- <info>Take the picture. If width and height are not specified or are 0 it will use the defaults. If width and height are specified, it will choose a supported photo size that is closest to width and height specified and has closest aspect ratio to the preview. The argument `quality` defaults to `85` and specifies the quality/compression value: `0=max compression`, `100=max quality`.</info><br/> -->
 

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -89,6 +89,7 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
         saveCall(call);
 
         Integer quality = call.getInt("quality", 85);
+        // Image Dimensions - Optional
         Integer width = call.getInt("width", 0);
         Integer height = call.getInt("height", 0);
         fragment.takePicture(width, height, quality);

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -28,7 +28,9 @@ export interface CameraPreviewOptions {
   position?: CameraPosition | string;
 }
 export interface CameraPreviewPictureOptions {
+  /** The picture height, optional, default 0 (Device default) */
   height?: number;
+  /** The picture width, optional, default 0 (Device default) */
   width?: number;
   /** The picture quality, 0 - 100, default 85 */
   quality?: number;


### PR DESCRIPTION
If width and height are not specified or are 0 it will use the defaults. If width and height are specified, it will choose a supported photo size that is closest to width and height specified and has closest aspect ratio to the preview.