### PR TITLE
Camera Orientations - disableExifHeaderStripping

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Starts the camera preview instance.
 | toBack   | boolean       | (optional) Brings your html in front of your preview, default false (applicable to the android and ios platforms only) |
 | paddingBottom | number       | (optional) The preview bottom padding in pixes. Useful to keep the appropriate preview sizes when orientation changes (applicable to the android and ios platforms only)           |
 | rotateWhenOrientationChanged | boolean   | (optional) Rotate preview when orientation changes (applicable to the ios platforms only; default value is true)                                                      |
+| storeToFile | boolean       | (optional) Capture images to a file and return back the file path instead of returning base64 encoded data, default false. |
+| disableExifHeaderStripping | boolean       | (optional) Disable automatic rotation of the image, and let the browser deal with it, default true (applicable to the android and ios platforms only) |
 
 <!-- <strong>Options:</strong>
 All options stated are optional and will default to values here

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
     implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.exifinterface:exifinterface:1.0.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
@@ -18,7 +18,7 @@ import android.hardware.Camera.PictureCallback;
 import android.hardware.Camera.ShutterCallback;
 import android.media.CamcorderProfile;
 import android.media.MediaRecorder;
-import android.media.ExifInterface;
+import androidx.exifinterface.media.ExifInterface;
 import android.view.Surface;
 import android.os.Bundle;
 import android.util.Base64;
@@ -655,34 +655,28 @@ public class CameraActivity extends Fragment {
             params.setJpegQuality(quality);
           }
 
-          if(cameraCurrentlyLocked == Camera.CameraInfo.CAMERA_FACING_FRONT) {
+          if(cameraCurrentlyLocked == Camera.CameraInfo.CAMERA_FACING_FRONT && disableExifHeaderStripping) {
             Activity activity = getActivity();
             int rotation = activity.getWindowManager().getDefaultDisplay().getRotation();
             int degrees = 0;
             switch (rotation) {
               case Surface.ROTATION_0:
-                degrees = 270;
-                // degrees = 0; // before change
+                degrees = 0;
                 break;
               case Surface.ROTATION_90:
-                degrees = 0;
-                // degrees = 180; // before change
+                degrees = 180;
                 break;
               case Surface.ROTATION_180:
-                degrees = 90;
-                // degrees = 270; // before change
+                degrees = 270;
                 break;
               case Surface.ROTATION_270:
-                degrees = 180;
-                // degrees = 0; // before change
+                degrees = 0;
                 break;
             }
             params.setRotation(degrees);
           } else {
             params.setRotation(mPreview.getDisplayOrientation());
           }
-
-          // params.setRotation(mPreview.getDisplayOrientation());
 
           mCamera.setParameters(params);
           mCamera.takePicture(shutterCallback, null, jpegPictureCallback);

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -213,7 +213,8 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
         final Integer height = call.getInt("height", 0);
         final Integer paddingBottom = call.getInt("paddingBottom", 0);
         final Boolean toBack = call.getBoolean("toBack", false);
-	final Boolean storeToFile = call.getBoolean("storeToFile", false);
+        final Boolean storeToFile = call.getBoolean("storeToFile", false);
+        final Boolean disableExifHeaderStripping = call.getBoolean("disableExifHeaderStripping", true);
 
         fragment = new CameraActivity();
         fragment.setEventListener(this);
@@ -221,7 +222,7 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
         fragment.tapToTakePicture = false;
         fragment.dragEnabled = false;
         fragment.tapToFocus = true;
-        fragment.disableExifHeaderStripping = true;
+        fragment.disableExifHeaderStripping = disableExifHeaderStripping;
         fragment.storeToFile = storeToFile;
         fragment.toBack = toBack;
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -26,6 +26,10 @@ export interface CameraPreviewOptions {
   rotateWhenOrientationChanged?: boolean;
   /** Choose the camera to use 'front' or 'rear', default 'front' */
   position?: CameraPosition | string;
+  /** Defaults to false - Capture images to a file and return back the file path instead of returning base64 encoded data */
+  storeToFile?: boolean;
+  /** Defaults to false - Android Only - Disable automatic rotation of the image, and let the browser deal with it (keep reading on how to achieve it) */
+  disableExifHeaderStripping?: boolean;
 }
 export interface CameraPreviewPictureOptions {
   /** The picture height, optional, default 0 (Device default) */


### PR DESCRIPTION
Performing some tests and after sending the image to a web service, the image always remained in landscape mode, even removing changes in orientation.
Researching a little about, I identified that the problem happens due to the image metadata.
I included in the plugin the disableExifHeaderStripping option as a boolean, keeping the default value true as before.