### PR TITLE
Update README with `npx cap sync`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ or
 
 npm install @capacitor-community/camera-preview
 ```
+Then run
+```
+npx cap sync
+```
+
 #### Android Quirks
 
 On Android remember to add the plugin to `MainActivity`


### PR DESCRIPTION
This PR is to update the README with the additional installation step `npx cap sync`.

I had some very confusing errors because I had forgotten to run `npx cap sync` after installation. Yes, I know it seems obvious, but those who are new to Ionic (such as myself) may not remember/know that they need to run this after the installation of a plugin.

Thanks for the great work on this plugin!