### PR TITLE
Enable high resolution capture on iOS

### DIFF
--- a/ios/Plugin/CameraController.swift
+++ b/ios/Plugin/CameraController.swift
@@ -26,6 +26,8 @@ class CameraController: NSObject {
     
     var flashMode = AVCaptureDevice.FlashMode.off
     var photoCaptureCompletionBlock: ((UIImage?, Error?) -> Void)?
+
+    var highResolutionOutput: Bool = false
 }
 
 extension CameraController {
@@ -33,61 +35,62 @@ extension CameraController {
         func createCaptureSession() {
             self.captureSession = AVCaptureSession()
         }
-        
+
         func configureCaptureDevices() throws {
-            
+
             let session = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: AVMediaType.video, position: .unspecified)
-            
+
             let cameras = session.devices.compactMap { $0 }
             guard !cameras.isEmpty else { throw CameraControllerError.noCamerasAvailable }
-            
+
             for camera in cameras {
                 if camera.position == .front {
                     self.frontCamera = camera
                 }
-                
+
                 if camera.position == .back {
                     self.rearCamera = camera
-                    
+
                     try camera.lockForConfiguration()
                     camera.focusMode = .continuousAutoFocus
                     camera.unlockForConfiguration()
                 }
             }
         }
-        
+
         func configureDeviceInputs() throws {
             guard let captureSession = self.captureSession else { throw CameraControllerError.captureSessionIsMissing }
-            
+
             if cameraPosition == "rear" {
                 if let rearCamera = self.rearCamera {
                     self.rearCameraInput = try AVCaptureDeviceInput(device: rearCamera)
-                    
+
                     if captureSession.canAddInput(self.rearCameraInput!) { captureSession.addInput(self.rearCameraInput!) }
-                    
+
                     self.currentCameraPosition = .rear
                 }
             } else if cameraPosition == "front" {
                 if let frontCamera = self.frontCamera {
                     self.frontCameraInput = try AVCaptureDeviceInput(device: frontCamera)
-                    
+
                     if captureSession.canAddInput(self.frontCameraInput!) { captureSession.addInput(self.frontCameraInput!) }
                     else { throw CameraControllerError.inputsAreInvalid }
-                    
+
                     self.currentCameraPosition = .front
                 }
             } else { throw CameraControllerError.noCamerasAvailable }
         }
-        
+
         func configurePhotoOutput() throws {
             guard let captureSession = self.captureSession else { throw CameraControllerError.captureSessionIsMissing }
-            
+
             self.photoOutput = AVCapturePhotoOutput()
             self.photoOutput!.setPreparedPhotoSettingsArray([AVCapturePhotoSettings(format: [AVVideoCodecKey : AVVideoCodecType.jpeg])], completionHandler: nil)
+            self.photoOutput?.isHighResolutionCaptureEnabled = self.highResolutionOutput
             if captureSession.canAddOutput(self.photoOutput!) { captureSession.addOutput(self.photoOutput!) }
             captureSession.startRunning()
         }
-        
+
         DispatchQueue(label: "prepare").async {
             do {
                 createCaptureSession()
@@ -95,27 +98,27 @@ extension CameraController {
                 try configureDeviceInputs()
                 try configurePhotoOutput()
             }
-                
+
             catch {
                 DispatchQueue.main.async {
                     completionHandler(error)
                 }
-                
+
                 return
             }
-            
+
             DispatchQueue.main.async {
                 completionHandler(nil)
             }
         }
     }
-    
+
     func displayPreview(on view: UIView) throws {
         guard let captureSession = self.captureSession, captureSession.isRunning else { throw CameraControllerError.captureSessionIsMissing }
-        
+
         self.previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
         self.previewLayer?.videoGravity = AVLayerVideoGravity.resizeAspectFill
-        
+
         let orientation: UIDeviceOrientation = UIDevice.current.orientation
         let statusBarOrientation = UIApplication.shared.statusBarOrientation
         switch (orientation) {
@@ -143,69 +146,72 @@ extension CameraController {
         default:
             self.previewLayer?.connection?.videoOrientation = .portrait
         }
-    
+
         view.layer.insertSublayer(self.previewLayer!, at: 0)
         self.previewLayer?.frame = view.frame
     }
-    
+
     func switchCameras() throws {
         guard let currentCameraPosition = currentCameraPosition, let captureSession = self.captureSession, captureSession.isRunning else { throw CameraControllerError.captureSessionIsMissing }
-        
+
         captureSession.beginConfiguration()
-        
+
         func switchToFrontCamera() throws {
-            
+
             guard let rearCameraInput = self.rearCameraInput, captureSession.inputs.contains(rearCameraInput),
                 let frontCamera = self.frontCamera else { throw CameraControllerError.invalidOperation }
-            
+
             self.frontCameraInput = try AVCaptureDeviceInput(device: frontCamera)
-            
+
             captureSession.removeInput(rearCameraInput)
-            
+
             if captureSession.canAddInput(self.frontCameraInput!) {
                 captureSession.addInput(self.frontCameraInput!)
-                
+
                 self.currentCameraPosition = .front
             }
-                
+
             else {
                 throw CameraControllerError.invalidOperation
             }
         }
-        
+
         func switchToRearCamera() throws {
-            
+
             guard let frontCameraInput = self.frontCameraInput, captureSession.inputs.contains(frontCameraInput),
                 let rearCamera = self.rearCamera else { throw CameraControllerError.invalidOperation }
-            
+
             self.rearCameraInput = try AVCaptureDeviceInput(device: rearCamera)
-            
+
             captureSession.removeInput(frontCameraInput)
-            
+
             if captureSession.canAddInput(self.rearCameraInput!) {
                 captureSession.addInput(self.rearCameraInput!)
-                
+
                 self.currentCameraPosition = .rear
             }
-                
+
             else { throw CameraControllerError.invalidOperation }
         }
-        
+
         switch currentCameraPosition {
         case .front:
             try switchToRearCamera()
-            
+
         case .rear:
             try switchToFrontCamera()
         }
-        
+
         captureSession.commitConfiguration()
     }
-    
+
     func captureImage(completion: @escaping (UIImage?, Error?) -> Void) {
         guard let captureSession = captureSession, captureSession.isRunning else { completion(nil, CameraControllerError.captureSessionIsMissing); return }
         let settings = AVCapturePhotoSettings()
+
         settings.flashMode = self.flashMode
+        settings.isHighResolutionPhotoEnabled = self.highResolutionOutput;
+
         let currentDevice: UIDevice = .current
         let deviceOrientation: UIDeviceOrientation = currentDevice.orientation
         let statusBarOrientation = UIApplication.shared.statusBarOrientation

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -19,20 +19,21 @@ public class CameraPreview: CAPPlugin {
     var rotateWhenOrientationChanged: Bool?
     var toBack: Bool?
     var storeToFile: Bool?
-    
+    var highResolutionOutput: Bool = false
+
     @objc func rotated() {
-        
+
         let height = self.paddingBottom != nil ? self.height! - self.paddingBottom!: self.height!;
 
         if UIDevice.current.orientation.isLandscape {
-            
+
             self.previewView.frame = CGRect(x: self.y!, y: self.x!, width: height, height: self.width!)
             self.cameraController.previewLayer?.frame = self.previewView.frame
-            
+
             if (UIDevice.current.orientation == UIDeviceOrientation.landscapeLeft) {
                 self.cameraController.previewLayer?.connection?.videoOrientation = .landscapeRight
             }
-            
+
             if (UIDevice.current.orientation == UIDeviceOrientation.landscapeRight) {
                 self.cameraController.previewLayer?.connection?.videoOrientation = .landscapeLeft
             }
@@ -47,7 +48,9 @@ public class CameraPreview: CAPPlugin {
 
     @objc func start(_ call: CAPPluginCall) {
         self.cameraPosition = call.getString("position") ?? "rear"
-        
+        self.highResolutionOutput = call.getBool("enableHighResolution") ?? false
+        self.cameraController.highResolutionOutput = self.highResolutionOutput;
+
         if call.getInt("width") != nil {
             self.width = CGFloat(call.getInt("width")!)
         } else {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "npm run clean && tsc",
     "clean": "rm -rf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "prepare": "npm run build"
   },
   "author": "Ariel Hernandez Musa",
   "license": "MIT",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -30,6 +30,8 @@ export interface CameraPreviewOptions {
   storeToFile?: boolean;
   /** Defaults to false - Android Only - Disable automatic rotation of the image, and let the browser deal with it (keep reading on how to achieve it) */
   disableExifHeaderStripping?: boolean;
+  /** Defaults to false - iOS only - Activate high resolution image capture so that output images are from the highest resolution possible on the device **/
+  enableHighResolution?: boolean;
 }
 export interface CameraPreviewPictureOptions {
   /** The picture height, optional, default 0 (Device default) */


### PR DESCRIPTION
For now images taken with an Apple device are limited in resolution. I've added a flag to activate high resolution capture, allowing users to take full resolution pictures.

Also added a prepare step for npm so that the plugin is correctly built when installed from github.