### PR TITLE
fix: compressionQuality is between 0 and 1 in jpegData

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -155,9 +155,9 @@ public class CameraPreview: CAPPlugin {
             let imageData: Data?
             if (self.cameraPosition == "front") {
                 let flippedImage = image.withHorizontallyFlippedOrientation()
-                imageData = flippedImage.jpegData(compressionQuality: CGFloat(quality!))
+                imageData = flippedImage.jpegData(compressionQuality: CGFloat(quality!/100))
             } else {
-                imageData = image.jpegData(compressionQuality: CGFloat(quality!))
+                imageData = image.jpegData(compressionQuality: CGFloat(quality!/100))
             }
 
             if (self.storeToFile == false){


### PR DESCRIPTION
There was a bad API usage of jpegData. Value must be between 0 and 1:

https://developer.apple.com/documentation/uikit/1624115-uiimagejpegrepresentation?language=swift

```
compressionQuality
The quality of the resulting JPEG image, expressed as a value from 0.0 to 1.0. The value 0.0 represents the maximum compression (or lowest quality) while the value 1.0 represents the least compression (or best quality).
```

This PR aims to fix this issue.