### PR TITLE
Fix non-available rm command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/esm/index.d.ts",
   "scripts": {
     "build": "npm run clean && tsc",
-    "clean": "npx del ('./dist')",
+    "clean": "rimraf './dist'",
     "watch": "tsc --watch",
     "prepublishOnly": "npm run build",
     "prepare": "npm run build"
@@ -20,7 +20,7 @@
     "@capacitor/android": "latest",
     "@capacitor/ios": "latest",
     "typescript": "^3.2.4",
-    "del": "latest"
+    "rimraf": "latest"
   },
   "files": [
     "dist/",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/esm/index.d.ts",
   "scripts": {
     "build": "npm run clean && tsc",
-    "clean": "rm -rf ./dist",
+    "clean": "npx del ('./dist')",
     "watch": "tsc --watch",
     "prepublishOnly": "npm run build",
     "prepare": "npm run build"
@@ -19,7 +19,8 @@
   "devDependencies": {
     "@capacitor/android": "latest",
     "@capacitor/ios": "latest",
-    "typescript": "^3.2.4"
+    "typescript": "^3.2.4",
+    "del": "latest"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
The npm package `rimraf` is used to make the remove action more abstract and also allows it to work on Windows and everywhere else where `rm` is not available.