### PR TITLE
fix iOS capture flipped image after camera flip

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -156,7 +156,7 @@ public class CameraPreview: CAPPlugin {
                 return
             }
             let imageData: Data?
-            if (self.cameraPosition == "front") {
+            if (self.cameraController.currentCameraPosition == .front) {
                 let flippedImage = image.withHorizontallyFlippedOrientation()
                 imageData = flippedImage.jpegData(compressionQuality: CGFloat(quality!/100))
             } else {


### PR DESCRIPTION
This PR fixes an issue when capturing an image after calling `CameraPreview.flip()`. 

Bug description:

When starting the front camera the captured image is always flipped, even after switching to rear, viceversa when starting the rear camera and switching to front the captured image is not flipped.