### PR TITLE
iOS Safari additional attributes needed

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -45,6 +45,18 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
           );
         }
 
+        const userAgent = navigator.userAgent.toLowerCase();
+        const isSafari = userAgent.includes('safari') && !userAgent.includes('chrome');
+
+        // Safari on iOS needs to have the autoplay, muted and playsinline attributes set for video.play() to be successful
+        // Without these attributes videoElement.play() will throw a NotAllowedError
+        // https://developer.apple.com/documentation/webkit/delivering_video_content_for_safari
+        if (isSafari) {
+          videoElement.setAttribute('autoplay', 'true');
+          videoElement.setAttribute('muted', 'true');
+          videoElement.setAttribute('playsinline', 'true');
+        }
+
         parent.appendChild(videoElement);
 
         if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {


### PR DESCRIPTION
`videoElement.play()` throws a NotAllowedError if `autoplay`, `muted` and `playsinline` are not set on iOS Safari. Adding check for safari and apply attributes as necessary. 