### PR TITLE
fixed a fatal error that can occur when an iOS app is put in the back…

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -40,7 +40,9 @@ public class CameraPreview: CAPPlugin {
         }
 
         if UIDevice.current.orientation.isPortrait {
-            self.previewView.frame = CGRect(x: self.x!, y: self.y!, width: self.width!, height: self.height!)
+            if (self.previewView != nil && self.x != nil && self.y != nil && self.width != nil && self.height != nil) {
+                self.previewView.frame = CGRect(x: self.x!, y: self.y!, width: self.width!, height: self.height!)
+            }
             self.cameraController.previewLayer?.frame = self.previewView.frame
             self.cameraController.previewLayer?.connection?.videoOrientation = .portrait
         }


### PR DESCRIPTION
…ground (Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value: file CapacitorCommunityCameraPreview/Plugin.swift, line 43)