### PR TITLE
Fix camera display on iOS when rotated after opening in landscape

### DIFF
--- a/ios/Plugin/CameraController.swift
+++ b/ios/Plugin/CameraController.swift
@@ -151,32 +151,19 @@ extension CameraController {
         assert(Thread.isMainThread) // UIApplication.statusBarOrientation requires the main thread.
 
         let videoOrientation: AVCaptureVideoOrientation
-        switch UIDevice.current.orientation {
+        switch UIApplication.shared.statusBarOrientation {
         case .portrait:
             videoOrientation = .portrait
         case .landscapeLeft:
-            videoOrientation = .landscapeRight
-        case .landscapeRight:
             videoOrientation = .landscapeLeft
+        case .landscapeRight:
+            videoOrientation = .landscapeRight
         case .portraitUpsideDown:
             videoOrientation = .portraitUpsideDown
-        case .faceUp, .faceDown, .unknown:
+        case .unknown:
             fallthrough
         @unknown default:
-            switch UIApplication.shared.statusBarOrientation {
-            case .portrait:
-                videoOrientation = .portrait
-            case .landscapeLeft:
-                videoOrientation = .landscapeLeft
-            case .landscapeRight:
-                videoOrientation = .landscapeRight
-            case .portraitUpsideDown:
-                videoOrientation = .portraitUpsideDown
-            case .unknown:
-                fallthrough
-            @unknown default:
-                videoOrientation = .portrait
-            }
+            videoOrientation = .portrait
         }
 
         previewLayer?.connection?.videoOrientation = videoOrientation

--- a/ios/Plugin/CameraController.swift
+++ b/ios/Plugin/CameraController.swift
@@ -130,8 +130,6 @@ extension CameraController {
             }
 
             DispatchQueue.main.async {
-                self.updateVideoOrientation()
-
                 completionHandler(nil)
             }
         }
@@ -145,6 +143,8 @@ extension CameraController {
 
         view.layer.insertSublayer(self.previewLayer!, at: 0)
         self.previewLayer?.frame = view.frame
+
+        updateVideoOrientation()
     }
 
     func updateVideoOrientation() {

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -26,13 +26,13 @@ public class CameraPreview: CAPPlugin {
         let height = self.paddingBottom != nil ? self.height! - self.paddingBottom!: self.height!;
 
         if UIDevice.current.orientation.isLandscape {
-            self.previewView.frame = CGRect(x: self.y!, y: self.x!, width: height, height: self.width!)
+            self.previewView.frame = CGRect(x: self.y!, y: self.x!, width: max(height, self.width!), height: min(height, self.width!))
             self.cameraController.previewLayer?.frame = self.previewView.frame
         }
 
         if UIDevice.current.orientation.isPortrait {
             if (self.previewView != nil && self.x != nil && self.y != nil && self.width != nil && self.height != nil) {
-                self.previewView.frame = CGRect(x: self.x!, y: self.y!, width: self.width!, height: self.height!)
+                self.previewView.frame = CGRect(x: self.x!, y: self.y!, width: min(height, self.width!), height: max(height, self.width!))
             }
             self.cameraController.previewLayer?.frame = self.previewView.frame
         }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -25,12 +25,12 @@ public class CameraPreview: CAPPlugin {
 
         let height = self.paddingBottom != nil ? self.height! - self.paddingBottom!: self.height!;
 
-        if UIDevice.current.orientation.isLandscape {
+        if UIApplication.shared.statusBarOrientation.isLandscape {
             self.previewView.frame = CGRect(x: self.y!, y: self.x!, width: max(height, self.width!), height: min(height, self.width!))
             self.cameraController.previewLayer?.frame = self.previewView.frame
         }
 
-        if UIDevice.current.orientation.isPortrait {
+        if UIApplication.shared.statusBarOrientation.isPortrait {
             if (self.previewView != nil && self.x != nil && self.y != nil && self.width != nil && self.height != nil) {
                 self.previewView.frame = CGRect(x: self.x!, y: self.y!, width: min(height, self.width!), height: max(height, self.width!))
             }


### PR DESCRIPTION
On iOS, if you enable the camera preview while the device is in landscape and rotate the device to portrait, the preview layer's  width and height are reversed and the preview only appears to take up half the screen.