### PR TITLE
Fix capacitor version 2 dependecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
   "author": "Ariel Hernandez Musa",
   "license": "MIT",
   "dependencies": {
-    "@capacitor/core": "latest"
+    "@capacitor/core": "^2.4.7"
   },
   "devDependencies": {
-    "@capacitor/android": "latest",
-    "@capacitor/ios": "latest",
+    "@capacitor/android": "^2.4.7",
+    "@capacitor/ios": "^2.4.7",
     "typescript": "^3.2.4",
     "rimraf": "latest"
   },


### PR DESCRIPTION
This PR fixes capacitor 2 dependency. When using capacitor 2 npm downloads version 3.0 dependecy because in the package.json of this package is specified "latest"