### PR TITLE
Moving camera preparation into the callback of `requestAccess`. 

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -75,45 +75,48 @@ public class CameraPreview: CAPPlugin {
             self.paddingBottom = CGFloat(call.getInt("paddingBottom")!)
         }
 
-        AVCaptureDevice.requestAccess(for: .video, completionHandler: { (granted: Bool) in
-            if (!granted) {
-                call.reject("permission failed");
-            }
-        });
-
         self.rotateWhenOrientationChanged = call.getBool("rotateWhenOrientationChanged") ?? true
         self.toBack = call.getBool("toBack") ?? false
         self.storeToFile = call.getBool("storeToFile") ?? false
 
-        if (self.rotateWhenOrientationChanged == true) {
-            NotificationCenter.default.addObserver(self, selector: #selector(CameraPreview.rotated), name: UIDevice.orientationDidChangeNotification, object: nil)
-        }
-        
-        DispatchQueue.main.async {
-            if (self.cameraController.captureSession?.isRunning ?? false) {
-                call.reject("camera already started")
-            } else {
-                self.cameraController.prepare(cameraPosition: self.cameraPosition){error in
-                    if let error = error {
-                        print(error)
-                        call.reject(error.localizedDescription)
-                        return
-                    }
-                    let height = self.paddingBottom != nil ? self.height! - self.paddingBottom!: self.height!;
-                    self.previewView = UIView(frame: CGRect(x: 0, y: 0, width: self.width!, height: height))
-                    self.webView?.isOpaque = false
-                    self.webView?.backgroundColor = UIColor.clear
-                    self.webView?.scrollView.backgroundColor = UIColor.clear
-                    self.webView?.superview?.addSubview(self.previewView)
-                    if (self.toBack!) {
-                        self.webView?.superview?.bringSubviewToFront(self.webView!)
-                    }
-                    try? self.cameraController.displayPreview(on: self.previewView)
-                    call.resolve()
+        AVCaptureDevice.requestAccess(for: .video, completionHandler: { (granted: Bool) in
+            guard granted else {
+                call.reject("permission failed");
+                return
+            }
+            
+            DispatchQueue.main.async {
+                if (self.cameraController.captureSession?.isRunning ?? false) {
+                    call.reject("camera already started")
+                } else {
+                    self.cameraController.prepare(cameraPosition: self.cameraPosition){error in
+                        if let error = error {
+                            print(error)
+                            call.reject(error.localizedDescription)
+                            return
+                        }
+                        let height = self.paddingBottom != nil ? self.height! - self.paddingBottom!: self.height!;
+                        self.previewView = UIView(frame: CGRect(x: 0, y: 0, width: self.width!, height: height))
+                        self.webView?.isOpaque = false
+                        self.webView?.backgroundColor = UIColor.clear
+                        self.webView?.scrollView.backgroundColor = UIColor.clear
+                        self.webView?.superview?.addSubview(self.previewView)
+                        if (self.toBack!) {
+                            self.webView?.superview?.bringSubviewToFront(self.webView!)
+                        }
+                        try? self.cameraController.displayPreview(on: self.previewView)
+                        
+                        if (self.rotateWhenOrientationChanged == true) {
+                            NotificationCenter.default.addObserver(self, selector: #selector(CameraPreview.rotated), name: UIDevice.orientationDidChangeNotification, object: nil)
+                        }
+                        
+                        call.resolve()
 
+                    }
                 }
             }
-        }
+        });
+        
     }
 
     @objc func flip(_ call: CAPPluginCall) {


### PR DESCRIPTION
Hey @pbowyer, I was doing some more with the Capacitor 3 upgrade and I noticed that the underlying promise for iOS permissions resolves before the prompt is answered by the user. If the user is doesn't answer the prompt right away.

I'm fixing that here by moving the `DispatchQueue.main.async` within the callback of `AVCaptureDevice.requestAccess`.