### PR TITLE
Add Opacity for web and Android, Support pinch/zoom for Android

### DIFF
--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -3,13 +3,17 @@ package com.ahm.capacitor.camera.preview;
 import android.Manifest;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
+
 import android.content.pm.ActivityInfo;
 import android.graphics.Color;
 import android.graphics.Point;
 import android.hardware.Camera;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
+import android.util.Log;
 import android.view.Display;
+import android.view.MotionEvent;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
@@ -24,441 +28,478 @@ import org.json.JSONArray;
 import java.io.File;
 import java.util.List;
 
+
 @NativePlugin(
-        permissions = {
-                Manifest.permission.CAMERA
-        },
-        requestCodes = {
-                CameraPreview.REQUEST_CAMERA_PERMISSION
-        }
+  permissions = {
+    Manifest.permission.CAMERA
+  },
+  requestCodes = {
+    CameraPreview.REQUEST_CAMERA_PERMISSION
+  }
 )
 public class CameraPreview extends Plugin implements CameraActivity.CameraPreviewListener {
-    private static String VIDEO_FILE_PATH = "";
-    private static String VIDEO_FILE_EXTENSION = ".mp4";
-    static final int REQUEST_CAMERA_PERMISSION = 1234;
+  private static String VIDEO_FILE_PATH = "";
+  private static String VIDEO_FILE_EXTENSION = ".mp4";
+  static final int REQUEST_CAMERA_PERMISSION = 1234;
 
-    // keep track of previously specified orientation to support locking orientation:
-    private int previousOrientationRequest = -1;
+  // keep track of previously specified orientation to support locking orientation:
+  private int previousOrientationRequest = -1;
 
-    private CameraActivity fragment;
-    private int containerViewId = 20;
+  private CameraActivity fragment;
+  private int containerViewId = 20;
+  private static final String TAG = "CameraPreview";
 
-    @PluginMethod()
-    public void echo(PluginCall call) {
-        String value = call.getString("value");
 
-        JSObject ret = new JSObject();
-        ret.put("value", value);
-        call.success(ret);
+  @PluginMethod()
+  public void echo(PluginCall call) {
+    String value = call.getString("value");
+
+    JSObject ret = new JSObject();
+    ret.put("value", value);
+    call.success(ret);
+  }
+
+  @PluginMethod()
+  public void start(PluginCall call) {
+    saveCall(call);
+
+    if (hasRequiredPermissions()) {
+      startCamera(call);
+    } else {
+      pluginRequestPermissions(new String[]{
+        Manifest.permission.CAMERA
+      }, REQUEST_CAMERA_PERMISSION);
+    }
+  }
+
+  @PluginMethod
+  public void flip(PluginCall call) {
+    try {
+      fragment.switchCamera();
+      call.resolve();
+    } catch (Exception e) {
+      call.reject("failed to flip camera");
+    }
+  }
+
+  @PluginMethod
+  public void setOpacity(PluginCall call) {
+    if (this.hasCamera(call) == false) {
+      call.error("Camera is not running");
+      return;
     }
 
-    @PluginMethod()
-    public void start(PluginCall call) {
-        saveCall(call);
+    saveCall(call);
+    Float opacity = call.getFloat("opacity", 1F);
+    fragment.setOpacity(opacity);
+  }
 
-        if (hasRequiredPermissions()) {
-            startCamera(call);
+  @PluginMethod()
+  public void capture(PluginCall call) {
+    if (this.hasCamera(call) == false) {
+      call.error("Camera is not running");
+      return;
+    }
+
+    saveCall(call);
+
+    Integer quality = call.getInt("quality", 85);
+    // Image Dimensions - Optional
+    Integer width = call.getInt("width", 0);
+    Integer height = call.getInt("height", 0);
+    fragment.takePicture(width, height, quality);
+  }
+
+
+  @PluginMethod()
+  public void captureSample(PluginCall call) {
+    if (this.hasCamera(call) == false) {
+      call.error("Camera is not running");
+      return;
+    }
+    saveCall(call);
+    Integer quality = call.getInt("quality", 85);
+    fragment.takeSnapshot(quality);
+  }
+
+  @PluginMethod()
+  public void stop(final PluginCall call) {
+    bridge.getActivity().runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        FrameLayout containerView = getBridge().getActivity().findViewById(containerViewId);
+
+        // allow orientation changes after closing camera:
+        getBridge().getActivity().setRequestedOrientation(previousOrientationRequest);
+
+        if (containerView != null) {
+          ((ViewGroup) getBridge().getWebView().getParent()).removeView(containerView);
+          getBridge().getWebView().setBackgroundColor(Color.WHITE);
+          FragmentManager fragmentManager = getActivity().getFragmentManager();
+          FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+          fragmentTransaction.remove(fragment);
+          fragmentTransaction.commit();
+          fragment = null;
+
+          call.success();
         } else {
-            pluginRequestPermissions(new String[]{
-                    Manifest.permission.CAMERA
-            }, REQUEST_CAMERA_PERMISSION);
+          call.reject("camera already stopped");
         }
+      }
+    });
+  }
+
+  @PluginMethod()
+  public void getSupportedFlashModes(PluginCall call) {
+    if (this.hasCamera(call) == false) {
+      call.error("Camera is not running");
+      return;
     }
 
-    @PluginMethod
-    public void flip(PluginCall call) {
-        try {
-            fragment.switchCamera();
-            call.resolve();
-        } catch (Exception e) {
-            call.reject("failed to flip camera");
-        }
+    Camera camera = fragment.getCamera();
+    Camera.Parameters params = camera.getParameters();
+    List <String> supportedFlashModes;
+    supportedFlashModes = params.getSupportedFlashModes();
+    JSONArray jsonFlashModes = new JSONArray();
+
+    if (supportedFlashModes != null) {
+      for (int i = 0; i < supportedFlashModes.size(); i++) {
+        jsonFlashModes.put(new String(supportedFlashModes.get(i)));
+      }
     }
 
-    @PluginMethod()
-    public void capture(PluginCall call) {
-        if(this.hasCamera(call) == false){
-            call.error("Camera is not running");
-            return;
+    JSObject jsObject = new JSObject();
+    jsObject.put("result", jsonFlashModes);
+    call.success(jsObject);
+
+  }
+
+  @PluginMethod()
+  public void setFlashMode(PluginCall call) {
+    if (this.hasCamera(call) == false) {
+      call.error("Camera is not running");
+      return;
+    }
+
+    String flashMode = call.getString("flashMode");
+    if (flashMode == null || flashMode.isEmpty() == true) {
+      call.error("flashMode required parameter is missing");
+      return;
+    }
+
+    Camera camera = fragment.getCamera();
+    Camera.Parameters params = camera.getParameters();
+
+    List <String> supportedFlashModes;
+    supportedFlashModes = camera.getParameters().getSupportedFlashModes();
+    if (supportedFlashModes.indexOf(flashMode) > -1) {
+      params.setFlashMode(flashMode);
+    } else {
+      call.error("Flash mode not recognised: " + flashMode);
+      return;
+    }
+
+    fragment.setCameraParameters(params);
+
+    call.success();
+  }
+
+  @Override
+  protected void handleRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+    super.handleRequestPermissionsResult(requestCode, permissions, grantResults);
+    if (requestCode == REQUEST_CAMERA_PERMISSION) {
+      boolean permissionsGranted = true;
+      for (int grantResult : grantResults) {
+        if (grantResult != 0) {
+          permissionsGranted = false;
         }
+      }
 
-        saveCall(call);
-
-        Integer quality = call.getInt("quality", 85);
-        // Image Dimensions - Optional
-        Integer width = call.getInt("width", 0);
-        Integer height = call.getInt("height", 0);
-        fragment.takePicture(width, height, quality);
+      PluginCall savedCall = getSavedCall();
+      if (permissionsGranted) {
+        startCamera(savedCall);
+      } else {
+        savedCall.reject("permission failed");
+      }
     }
 
 
-    @PluginMethod()
-    public void captureSample(PluginCall call) {
-        if(this.hasCamera(call) == false){
-            call.error("Camera is not running");
-            return;
-        }
-        saveCall(call);
-        Integer quality = call.getInt("quality", 85);
-        fragment.takeSnapshot(quality);
+  }
+
+  private void startCamera(final PluginCall call) {
+
+    String position = call.getString("position");
+
+    if (position == null || position.isEmpty() || "rear".equals(position)) {
+      position = "back";
+    } else {
+      position = "front";
     }
 
-    @PluginMethod()
-    public void stop(final PluginCall call) {
-        bridge.getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                FrameLayout containerView = getBridge().getActivity().findViewById(containerViewId);
+    final Integer x = call.getInt("x", 0);
+    final Integer y = call.getInt("y", 0);
+    final Integer width = call.getInt("width", 0);
+    final Integer height = call.getInt("height", 0);
+    final Integer paddingBottom = call.getInt("paddingBottom", 0);
+    final Boolean enableOpacity = call.getBoolean("enableOpacity", false);
+    final Boolean toBack = call.getBoolean("toBack", false);
+    final Boolean storeToFile = call.getBoolean("storeToFile", false);
+    final Boolean disableExifHeaderStripping = call.getBoolean("disableExifHeaderStripping", true);
+    final Boolean lockOrientation = call.getBoolean("lockAndroidOrientation", false);
+    previousOrientationRequest = getBridge().getActivity().getRequestedOrientation();
 
-                // allow orientation changes after closing camera:
-                getBridge().getActivity().setRequestedOrientation(previousOrientationRequest);
+    fragment = new CameraActivity();
+    fragment.setEventListener(this);
+    fragment.defaultCamera = position;
+    fragment.tapToTakePicture = false;
+    fragment.dragEnabled = false;
+    fragment.tapToFocus = true;
+    fragment.disableExifHeaderStripping = disableExifHeaderStripping;
+    fragment.storeToFile = storeToFile;
+    fragment.toBack = toBack;
+    fragment.enableOpacity = enableOpacity;
 
-                if (containerView != null) {
-                    ((ViewGroup)getBridge().getWebView().getParent()).removeView(containerView);
-                    getBridge().getWebView().setBackgroundColor(Color.WHITE);
-                    FragmentManager fragmentManager = getActivity().getFragmentManager();
-                    FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
-                    fragmentTransaction.remove(fragment);
-                    fragmentTransaction.commit();
-                    fragment = null;
-
-                    call.success();
-                } else {
-                    call.reject("camera already stopped");
-                }
-            }
-        });
-    }
-
-    @PluginMethod()
-    public void getSupportedFlashModes(PluginCall call) {
-        if(this.hasCamera(call) == false){
-            call.error("Camera is not running");
-            return;
+    bridge.getActivity().runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        DisplayMetrics metrics = getBridge().getActivity().getResources().getDisplayMetrics();
+        // lock orientation if specified in options:
+        if (lockOrientation) {
+          getBridge().getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LOCKED);
         }
 
-        Camera camera = fragment.getCamera();
-        Camera.Parameters params = camera.getParameters();
-        List<String> supportedFlashModes;
-        supportedFlashModes = params.getSupportedFlashModes();
-        JSONArray jsonFlashModes = new JSONArray();
+        // offset
+        int computedX = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, x, metrics);
+        int computedY = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, y, metrics);
 
-        if (supportedFlashModes != null) {
-            for (int i=0; i<supportedFlashModes.size(); i++) {
-                jsonFlashModes.put(new String(supportedFlashModes.get(i)));
-            }
-        }
+        // size
+        int computedWidth;
+        int computedHeight;
+        int computedPaddingBottom;
 
-        JSObject jsObject = new JSObject();
-        jsObject.put("result", jsonFlashModes);
-        call.success(jsObject);
-
-    }
-
-    @PluginMethod()
-    public void setFlashMode(PluginCall call) {
-        if(this.hasCamera(call) == false){
-            call.error("Camera is not running");
-            return;
-        }
-
-        String flashMode = call.getString("flashMode");
-        if(flashMode == null || flashMode.isEmpty() == true) {
-            call.error("flashMode required parameter is missing");
-            return;
-        }
-
-        Camera camera = fragment.getCamera();
-        Camera.Parameters params = camera.getParameters();
-
-        List<String> supportedFlashModes;
-        supportedFlashModes = camera.getParameters().getSupportedFlashModes();
-        if (supportedFlashModes.indexOf(flashMode) > -1) {
-            params.setFlashMode(flashMode);
+        if (paddingBottom != 0) {
+          computedPaddingBottom = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, paddingBottom, metrics);
         } else {
-            call.error("Flash mode not recognised: " + flashMode);
-            return;
+          computedPaddingBottom = 0;
         }
 
-        fragment.setCameraParameters(params);
-
-        call.success();
-    }
-
-    @Override
-    protected void handleRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        super.handleRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (requestCode == REQUEST_CAMERA_PERMISSION) {
-            boolean permissionsGranted = true;
-            for (int grantResult: grantResults) {
-                if (grantResult != 0) {
-                    permissionsGranted = false;
-                }
-            }
-
-            PluginCall savedCall = getSavedCall();
-            if (permissionsGranted) {
-                startCamera(savedCall);
-            } else {
-                savedCall.reject("permission failed");
-            }
-        }
-
-
-
-    }
-
-    private void startCamera(final PluginCall call) {
-
-        String position = call.getString("position");
-
-        if (position == null || position.isEmpty() || "rear".equals(position)) {
-            position = "back";
+        if (width != 0) {
+          computedWidth = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, width, metrics);
         } else {
-            position = "front";
+          Display defaultDisplay = getBridge().getActivity().getWindowManager().getDefaultDisplay();
+          final Point size = new Point();
+          defaultDisplay.getSize(size);
+
+          computedWidth = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX, size.x, metrics);
         }
 
-        final Integer x = call.getInt("x", 0);
-        final Integer y = call.getInt("y", 0);
-        final Integer width = call.getInt("width", 0);
-        final Integer height = call.getInt("height", 0);
-        final Integer paddingBottom = call.getInt("paddingBottom", 0);
-        final Boolean toBack = call.getBoolean("toBack", false);
-        final Boolean storeToFile = call.getBoolean("storeToFile", false);
-        final Boolean disableExifHeaderStripping = call.getBoolean("disableExifHeaderStripping", true);
-        final Boolean lockOrientation = call.getBoolean("lockAndroidOrientation", false);
-        previousOrientationRequest = getBridge().getActivity().getRequestedOrientation();
+        if (height != 0) {
+          computedHeight = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, height, metrics) - computedPaddingBottom;
+        } else {
+          Display defaultDisplay = getBridge().getActivity().getWindowManager().getDefaultDisplay();
+          final Point size = new Point();
+          defaultDisplay.getSize(size);
 
-        fragment = new CameraActivity();
-        fragment.setEventListener(this);
-        fragment.defaultCamera = position;
-        fragment.tapToTakePicture = false;
-        fragment.dragEnabled = false;
-        fragment.tapToFocus = true;
-        fragment.disableExifHeaderStripping = disableExifHeaderStripping;
-        fragment.storeToFile = storeToFile;
-        fragment.toBack = toBack;
-
-        bridge.getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                DisplayMetrics metrics = getBridge().getActivity().getResources().getDisplayMetrics();
-                // lock orientation if specified in options:
-                if (lockOrientation) {
-                    getBridge().getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LOCKED);
-                }
-
-                // offset
-                int computedX = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, x, metrics);
-                int computedY = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, y, metrics);
-
-                // size
-                int computedWidth;
-                int computedHeight;
-                int computedPaddingBottom;
-
-                if(paddingBottom != 0) {
-                    computedPaddingBottom = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, paddingBottom, metrics);
-                } else {
-                    computedPaddingBottom = 0;
-                }
-
-                if(width != 0) {
-                    computedWidth = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, width, metrics);
-                } else {
-                    Display defaultDisplay = getBridge().getActivity().getWindowManager().getDefaultDisplay();
-                    final Point size = new Point();
-                    defaultDisplay.getSize(size);
-
-                    computedWidth = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX, size.x, metrics);
-                }
-
-                if(height != 0) {
-                    computedHeight = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, height, metrics) - computedPaddingBottom;
-                } else {
-                    Display defaultDisplay = getBridge().getActivity().getWindowManager().getDefaultDisplay();
-                    final Point size = new Point();
-                    defaultDisplay.getSize(size);
-
-                    computedHeight = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX, size.y, metrics) - computedPaddingBottom;
-                }
-
-                fragment.setRect(computedX, computedY, computedWidth, computedHeight);
-
-                FrameLayout containerView = getBridge().getActivity().findViewById(containerViewId);
-                if(containerView == null){
-                    containerView = new FrameLayout(getActivity().getApplicationContext());
-                    containerView.setId(containerViewId);
-
-                    getBridge().getWebView().setBackgroundColor(Color.TRANSPARENT);
-                    ((ViewGroup)getBridge().getWebView().getParent()).addView(containerView);
-                    if(toBack == true) {
-                        getBridge().getWebView().getParent().bringChildToFront(getBridge().getWebView());
-                    }
-
-                    FragmentManager fragmentManager = getBridge().getActivity().getFragmentManager();
-                    FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
-                    fragmentTransaction.add(containerView.getId(), fragment);
-                    fragmentTransaction.commit();
-
-                    call.success();
-                } else {
-                    call.reject("camera already started");
-                }
-            }
-        });
-    }
-
-
-    @Override
-    protected void handleOnResume() {
-        super.handleOnResume();
-    }
-
-    @Override
-    public void onPictureTaken(String originalPicture) {
-        JSObject jsObject = new JSObject();
-        jsObject.put("value", originalPicture);
-        getSavedCall().success(jsObject);
-    }
-
-    @Override
-    public void onPictureTakenError(String message) {
-        getSavedCall().reject(message);
-    }
-
-    @Override
-    public void onSnapshotTaken(String originalPicture) {
-        JSObject jsObject = new JSObject();
-        jsObject.put("value", originalPicture);
-        getSavedCall().success(jsObject);
-    }
-
-    @Override
-    public void onSnapshotTakenError(String message) {
-        getSavedCall().reject(message);
-    }
-
-    @Override
-    public void onFocusSet(int pointX, int pointY) {
-
-    }
-
-    @Override
-    public void onFocusSetError(String message) {
-
-    }
-
-    @Override
-    public void onBackButton() {
-
-    }
-
-    @Override
-    public void onCameraStarted() {
-        PluginCall pluginCall = getSavedCall();
-        System.out.println("camera started");
-        pluginCall.success();
-    }
-
-    @Override
-    public void onStartRecordVideo() {
-
-    }
-    @Override
-    public void onStartRecordVideoError(String message) {
-        getSavedCall().reject(message);
-    }
-    @Override
-    public void onStopRecordVideo(String file) {
-        PluginCall pluginCall = getSavedCall();
-        JSObject jsObject = new JSObject();
-        jsObject.put("videoFilePath", file);
-        pluginCall.success(jsObject);
-    }
-    @Override
-    public void onStopRecordVideoError(String error) {
-        getSavedCall().reject(error);
-    }
-
-    private boolean hasView(PluginCall call) {
-        if(fragment == null) {
-            return false;
+          computedHeight = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX, size.y, metrics) - computedPaddingBottom;
         }
 
-        return true;
+        fragment.setRect(computedX, computedY, computedWidth, computedHeight);
+
+        FrameLayout containerView = getBridge().getActivity().findViewById(containerViewId);
+        if (containerView == null) {
+          containerView = new FrameLayout(getActivity().getApplicationContext());
+          containerView.setId(containerViewId);
+
+          getBridge().getWebView().setBackgroundColor(Color.TRANSPARENT);
+          ((ViewGroup) getBridge().getWebView().getParent()).addView(containerView);
+          if (toBack == true) {
+            getBridge().getWebView().getParent().bringChildToFront(getBridge().getWebView());
+            setupBroadcast();
+          }
+
+          FragmentManager fragmentManager = getBridge().getActivity().getFragmentManager();
+          FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+          fragmentTransaction.add(containerView.getId(), fragment);
+          fragmentTransaction.commit();
+
+          call.success();
+        } else {
+          call.reject("camera already started");
+        }
+      }
+    });
+  }
+
+
+  @Override
+  protected void handleOnResume() {
+    super.handleOnResume();
+  }
+
+
+  @Override
+  public void onPictureTaken(String originalPicture) {
+    JSObject jsObject = new JSObject();
+    jsObject.put("value", originalPicture);
+    getSavedCall().success(jsObject);
+  }
+
+  @Override
+  public void onPictureTakenError(String message) {
+    getSavedCall().reject(message);
+  }
+
+  @Override
+  public void onSnapshotTaken(String originalPicture) {
+    JSObject jsObject = new JSObject();
+    jsObject.put("value", originalPicture);
+    getSavedCall().success(jsObject);
+  }
+
+  @Override
+  public void onSnapshotTakenError(String message) {
+    getSavedCall().reject(message);
+  }
+
+  @Override
+  public void onFocusSet(int pointX, int pointY) {
+
+  }
+
+  @Override
+  public void onFocusSetError(String message) {
+
+  }
+
+  @Override
+  public void onBackButton() {
+
+  }
+
+  @Override
+  public void onCameraStarted() {
+    PluginCall pluginCall = getSavedCall();
+    System.out.println("camera started");
+    pluginCall.success();
+  }
+
+  @Override
+  public void onStartRecordVideo() {
+
+  }
+
+  @Override
+  public void onStartRecordVideoError(String message) {
+    getSavedCall().reject(message);
+  }
+
+  @Override
+  public void onStopRecordVideo(String file) {
+    PluginCall pluginCall = getSavedCall();
+    JSObject jsObject = new JSObject();
+    jsObject.put("videoFilePath", file);
+    pluginCall.success(jsObject);
+  }
+
+  @Override
+  public void onStopRecordVideoError(String error) {
+    getSavedCall().reject(error);
+  }
+
+  private boolean hasView(PluginCall call) {
+    if (fragment == null) {
+      return false;
     }
 
-    private boolean hasCamera(PluginCall call) {
-        if(this.hasView(call) == false){
-            return false;
-        }
+    return true;
+  }
 
-        if(fragment.getCamera() == null) {
-            return false;
-        }
-
-        return true;
+  private boolean hasCamera(PluginCall call) {
+    if (this.hasView(call) == false) {
+      return false;
     }
 
-    @PluginMethod()
-    public void startRecordVideo(final PluginCall call) {
-        if(this.hasCamera(call) == false){
-            call.error("Camera is not running");
-            return;
-        }
-        final String filename = "videoTmp";
-        VIDEO_FILE_PATH = getActivity().getCacheDir().toString() + "/";
-
-        final String position = call.getString("position", "front");
-        final Integer width = call.getInt("width", 0);
-        final Integer height = call.getInt("height", 0);
-        final Boolean withFlash = call.getBoolean("withFlash", false);
-        final Integer maxDuration = call.getInt("maxDuration", 0);
-        // final Integer quality = call.getInt("quality", 0);
-
-        bridge.getActivity().runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                // fragment.startRecord(getFilePath(filename), position, width, height, quality, withFlash);
-                fragment.startRecord(getFilePath(filename), position, width, height, 70, withFlash, maxDuration);
-            }
-        });
-
-        call.success();
+    if (fragment.getCamera() == null) {
+      return false;
     }
 
-    @PluginMethod()
-    public void stopRecordVideo(PluginCall call) {
-       if(this.hasCamera(call) == false){
-            call.error("Camera is not running");
-            return;
-        }
+    return true;
+  }
 
-        saveCall(call);
+  @PluginMethod()
+  public void startRecordVideo(final PluginCall call) {
+    if (this.hasCamera(call) == false) {
+      call.error("Camera is not running");
+      return;
+    }
+    final String filename = "videoTmp";
+    VIDEO_FILE_PATH = getActivity().getCacheDir().toString() + "/";
 
-        // bridge.getActivity().runOnUiThread(new Runnable() {
-        //     @Override
-        //     public void run() {
-        //         fragment.stopRecord();
-        //     }
-        // });
+    final String position = call.getString("position", "front");
+    final Integer width = call.getInt("width", 0);
+    final Integer height = call.getInt("height", 0);
+    final Boolean withFlash = call.getBoolean("withFlash", false);
+    final Integer maxDuration = call.getInt("maxDuration", 0);
+    // final Integer quality = call.getInt("quality", 0);
 
-        fragment.stopRecord();
-        // call.success();
+    bridge.getActivity().runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        // fragment.startRecord(getFilePath(filename), position, width, height, quality, withFlash);
+        fragment.startRecord(getFilePath(filename), position, width, height, 70, withFlash, maxDuration);
+      }
+    });
+
+    call.success();
+  }
+
+  @PluginMethod()
+  public void stopRecordVideo(PluginCall call) {
+    if (this.hasCamera(call) == false) {
+      call.error("Camera is not running");
+      return;
     }
 
-    private String getFilePath(String filename) {
-        String fileName = filename;
+    saveCall(call);
 
-        int i = 1;
+    // bridge.getActivity().runOnUiThread(new Runnable() {
+    //     @Override
+    //     public void run() {
+    //         fragment.stopRecord();
+    //     }
+    // });
 
-        while (new File(VIDEO_FILE_PATH + fileName + VIDEO_FILE_EXTENSION).exists()) {
-        // Add number suffix if file exists
-        fileName = filename + '_' + i;
-        i++;
-        }
+    fragment.stopRecord();
+    // call.success();
+  }
 
-        return VIDEO_FILE_PATH + fileName + VIDEO_FILE_EXTENSION;
+  private String getFilePath(String filename) {
+    String fileName = filename;
+
+    int i = 1;
+
+    while (new File(VIDEO_FILE_PATH + fileName + VIDEO_FILE_EXTENSION).exists()) {
+      // Add number suffix if file exists
+      fileName = filename + '_' + i;
+      i++;
     }
+
+    return VIDEO_FILE_PATH + fileName + VIDEO_FILE_EXTENSION;
+  }
+
+  private void setupBroadcast() {
+    /** When touch event is triggered, relay it to camera view if needed so it can support pinch zoom */
+
+    getBridge().getWebView().setClickable(true);
+    getBridge().getWebView().setOnTouchListener(new View.OnTouchListener() {
+      @Override
+      public boolean onTouch(View v, MotionEvent event) {
+        if ((null != fragment) && (fragment.toBack == true)) {
+          fragment.frameContainerLayout.dispatchTouchEvent(event);
+        }
+        return false;
+      }
+    });
+  }
+
 }

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CustomTextureView.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CustomTextureView.java
@@ -1,0 +1,31 @@
+package com.ahm.capacitor.camera.preview;
+
+import android.content.Context;
+import android.graphics.SurfaceTexture;
+import android.view.SurfaceHolder;
+import android.view.TextureView;
+
+class CustomTextureView extends TextureView implements TextureView.SurfaceTextureListener{
+  private final String TAG = "CustomTextureView";
+
+  CustomTextureView(Context context){
+    super(context);
+  }
+
+  @Override
+  public void onSurfaceTextureAvailable(SurfaceTexture surface, int width, int height) {
+  }
+
+  @Override
+  public void onSurfaceTextureSizeChanged(SurfaceTexture surface, int width, int height) {
+  }
+
+  @Override
+  public boolean onSurfaceTextureDestroyed(SurfaceTexture surface) {
+    return true;
+  }
+
+  @Override
+  public void onSurfaceTextureUpdated(SurfaceTexture surface) {
+  }
+}

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -34,6 +34,8 @@ export interface CameraPreviewOptions {
   enableHighResolution?: boolean;
   /** Defaults to false - Web only - Disables audio stream to prevent permission requests and output switching */
   disableAudio?: boolean;
+  /** If camea preview will manage opacity.  Default is false */
+  enableOpacity?: boolean;
 }
 export interface CameraPreviewPictureOptions {
   /** The picture height, optional, default 0 (Device default) */
@@ -48,6 +50,10 @@ export interface CameraSampleOptions {
   /** The picture quality, 0 - 100, default 85 */
   quality?: number;
 }
+export interface CameraOpacityOptions {
+    /** The picture quality, 0 - 100, default 85 */
+    opacity?: number;
+}
 
 export type CameraPreviewFlashMode = 'off' | 'on' | 'auto' | 'red-eye' | 'torch';
 
@@ -61,4 +67,5 @@ export interface CameraPreviewPlugin {
   }>;
   setFlashMode(options: { flashMode: CameraPreviewFlashMode | string }): void;
   flip(): void;
+  setOpacity(options: CameraOpacityOptions): void;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -4,7 +4,8 @@ import {
   CameraPreviewPictureOptions, 
   CameraPreviewPlugin, 
   CameraPreviewFlashMode, 
-  CameraSampleOptions 
+  CameraSampleOptions ,
+  CameraOpacityOptions
 } from "./definitions";
 
 export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
@@ -152,6 +153,12 @@ export class CameraPreviewWeb extends WebPlugin implements CameraPreviewPlugin {
 
   async flip(): Promise<void> {
     throw new Error('flip not supported under the web platform');
+  }
+  async setOpacity(_options: CameraOpacityOptions): Promise<void> {
+	   const video = document.getElementById("video");
+	   if (!!video && !!_options['opacity']) {
+		   video.style.setProperty("opacity", _options['opacity']);
+	   }
   }
 }
 


### PR DESCRIPTION
Added a method to manage opacity for the camera preview, for web and Android.  Useful for AR type applications.

Also added pinch/zoom support for Android.  

Works for both settings for CameraPreview.toBack (true and false)