### PR TITLE
Add optional face detection

### DIFF
--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
@@ -321,6 +321,24 @@ public class CameraActivity extends Fragment {
       mCamera.setParameters(cameraParameters);
     }
 
+    // Begin my experiments
+    Camera.Parameters params = mCamera.getParameters();
+    //parameters.setSceneMode(Camera.Parameters.SCENE_MODE_PORTRAIT);
+    //mCamera.setParameters(params);
+
+//    if (faceDetectionRunning) {
+//      return 0;
+//    }
+    // check if face detection is supported or not
+    // using Camera.Parameters
+//    if (params.getMaxDetectedFaces() <= 0) {
+//      Log.e(TAG, "Face Detection not supported");
+//      return -1;
+//    }
+
+    //faceDetectionRunning = true;
+    // End my experiments
+
     cameraCurrentlyLocked = defaultCameraId;
 
     if(mPreview.mPreviewSize == null){
@@ -330,6 +348,13 @@ public class CameraActivity extends Fragment {
       mPreview.switchCamera(mCamera, cameraCurrentlyLocked);
       mCamera.startPreview();
     }
+    // Start my experiments
+    if (params.getMaxNumDetectedFaces() > 0) {
+      mCamera.setFaceDetectionListener(new MyFaceDetectionListener());
+      mCamera.startFaceDetection();
+      Log.d(TAG, "FACE DETECTION STARTED");
+    }
+    // End my experiments
 
     Log.d(TAG, "cameraCurrentlyLocked:" + cameraCurrentlyLocked);
 

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -5,6 +5,7 @@ import android.app.FragmentTransaction;
 import android.content.pm.ActivityInfo;
 import android.graphics.Color;
 import android.graphics.Point;
+import android.graphics.Rect;
 import android.hardware.Camera;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
@@ -27,6 +28,7 @@ import com.getcapacitor.annotation.PermissionCallback;
 import org.json.JSONArray;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
 import static android.Manifest.permission.CAMERA;
@@ -52,6 +54,7 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
 
     private CameraActivity fragment;
     private int containerViewId = 20;
+
 
     @PluginMethod()
     public void echo(PluginCall call) {
@@ -418,9 +421,7 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
     }
 
     @Override
-    public void onCameraStarted() {
-        System.out.println("camera started");
-    }
+    public void onCameraStarted() { System.out.println("camera started"); }
 
     @Override
     public void onStartRecordVideo() {

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/MyFaceDetectionListener.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/MyFaceDetectionListener.java
@@ -1,0 +1,36 @@
+package com.ahm.capacitor.camera.preview;
+
+import android.graphics.Rect;
+import android.hardware.Camera;
+
+import com.getcapacitor.Logger;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MyFaceDetectionListener implements Camera.FaceDetectionListener {
+
+    @Override
+    public void onFaceDetection(Camera.Face[] faces, Camera camera) {
+
+        if (faces.length == 0) {
+            Logger.info(this.getClass().getSimpleName(), "No faces detected");
+        } else if (faces.length > 0) {
+            Logger.info(this.getClass().getSimpleName(), "Faces Detected = " +
+                    String.valueOf(faces.length));
+
+            List<Rect> faceRects;
+            faceRects = new ArrayList<Rect>();
+
+            for (int i=0; i<faces.length; i++) {
+                int left = faces[i].rect.left;
+                int right = faces[i].rect.right;
+                int top = faces[i].rect.top;
+                int bottom = faces[i].rect.bottom;
+                Rect uRect = new Rect(left, top, right, bottom);
+                faceRects.add(uRect);
+            }
+
+            // add function to draw rects on view/surface/canvas
+        }
+    }
+}


### PR DESCRIPTION
Initial prototype for Android. At present it's crashing on launch.
```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.example.myapp, PID: 17926
    java.lang.RuntimeException: start face detection failed
        at android.hardware.Camera._startFaceDetection(Native Method)
        at android.hardware.Camera.startFaceDetection(Camera.java:1952)
        at com.ahm.capacitor.camera.preview.CameraActivity.onResume(CameraActivity.java:354)
        at android.app.Fragment.performResume(Fragment.java:2590)
        at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:1346)
        at android.app.FragmentManagerImpl.moveFragmentToExpectedState(FragmentManager.java:1581)
        at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:1643)
        at android.app.FragmentManagerImpl.executeOpsTogether(FragmentManager.java:2222)
        at android.app.FragmentManagerImpl.removeRedundantOperationsAndExecute(FragmentManager.java:2168)
        at android.app.FragmentManagerImpl.execPendingActions(FragmentManager.java:2069)
        at android.app.FragmentManagerImpl$1.run(FragmentManager.java:739)
        at android.os.Handler.handleCallback(Handler.java:907)
        at android.os.Handler.dispatchMessage(Handler.java:105)
        at android.os.Looper.loop(Looper.java:216)
        at android.app.ActivityThread.main(ActivityThread.java:7625)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:524)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:987)
```