### PR TITLE
iOS - always starts on position x=0 y=0

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -96,7 +96,7 @@ public class CameraPreview: CAPPlugin {
                             return
                         }
                         let height = self.paddingBottom != nil ? self.height! - self.paddingBottom!: self.height!;
-                        self.previewView = UIView(frame: CGRect(x: 0, y: 0, width: self.width!, height: height))
+                        self.previewView = UIView(frame: CGRect(x: self.x ?? 0, y: self.y ?? 0, width: self.width!, height: height))
                         self.webView?.isOpaque = false
                         self.webView?.backgroundColor = UIColor.clear
                         self.webView?.scrollView.backgroundColor = UIColor.clear


### PR DESCRIPTION
X and Y options are ignored in function start. With these changes default values are x=0, y=0 but it takes what it cames on parameters.