### PR TITLE
fix: Gradle 7 builds for capacitor 3 as recommended

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 30
     defaultConfig {
-        minSdkVersion 22
+        minSdkVersion 21
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -13,7 +13,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 30
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 22
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"
@@ -32,7 +32,6 @@ android {
 
 repositories {
     google()
-    jcenter()
     mavenCentral()
 }
 
@@ -40,11 +39,10 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'androidx.exifinterface:exifinterface:1.3.2'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    compile 'com.android.support:appcompat-v7:+'
 }
 


### PR DESCRIPTION
As say here : https://capacitorjs.com/docs/updating/3-0#update-gradle-to-70
Gradle 7 is the minium version for android, in capacitor 3.
- [jcenter become deprecated](https://docs.gradle.org/current/userguide/upgrading_version_6.html)
- [`compile` have been removed](https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal)