### PR TITLE
Fixed microphone permissions request on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Starts the camera preview instance.
 | storeToFile | boolean       | (optional) Capture images to a file and return back the file path instead of returning base64 encoded data, default false. |
 | disableExifHeaderStripping | boolean       | (optional) Disable automatic rotation of the image, and let the browser deal with it, default true (applicable to the android and ios platforms only) |
 | enableHighResolution | boolean       | (optional) Defaults to false - iOS only - Activate high resolution image capture so that output images are from the highest resolution possible on the device |
-| disableAudio | boolean | (optional) Disables audio stream to prevent permission requests, default false. (applicable to web only) |
+| disableAudio | boolean | (optional) Disables audio stream to prevent permission requests, default false. (applicable to web and iOS only) |
 | lockAndroidOrientation | boolean | (optional) Locks device orientation when camera is showing, default false. (applicable to Android only) |
 | enableOpacity | boolean | (optional) Make the camera preview see-through. Ideal for augmented reality uses. Default false (applicable to Android and web only)
 | enableZoom | boolean | (optional) Set if you can pinch to zoom. Default false (applicable to the android and ios platforms only)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Open `android/app/src/main/AndroidManifest.xml` and above the closing `</manifes
 For more help consult the [Capacitor docs](https://capacitorjs.com/docs/android/configuration#configuring-androidmanifestxml).
 
 ## Extra iOS installation steps
-You will need to add two permissions to `Info.plist`. Follow the [Capacitor docs](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) and add permissions with the raw keys `NSCameraUsageDescription` and `NSMicrophoneUsageDescription`.
+You will need to add two permissions to `Info.plist`. Follow the [Capacitor docs](https://capacitorjs.com/docs/ios/configuration#configuring-infoplist) and add permissions with the raw keys `NSCameraUsageDescription` and `NSMicrophoneUsageDescription`. `NSMicrophoneUsageDescription` is only required, if audio will be used. Otherwise set the `disableAudio` option to `true`, which also disables the microphone permission request.
 
 ## Extra Web installation steps
 Add `import '@capacitor-community/camera-preview'` to you entry script in ionic on `app.module.ts`, so capacitor can register the web platform from the plugin

--- a/ios/Plugin/CameraController.swift
+++ b/ios/Plugin/CameraController.swift
@@ -64,7 +64,7 @@ extension CameraController {
                     camera.unlockForConfiguration()
                 }
             }
-            if !disableAudio {
+            if disableAudio == false {
                 self.audioDevice = AVCaptureDevice.default(for: AVMediaType.audio)
             }
         }
@@ -92,7 +92,7 @@ extension CameraController {
             } else { throw CameraControllerError.noCamerasAvailable }
 
             // Add audio input
-            if !disableAudio {
+            if disableAudio == false {
                 if let audioDevice = self.audioDevice {
                     self.audioInput = try AVCaptureDeviceInput(device: audioDevice)
                     if captureSession.canAddInput(self.audioInput!) {

--- a/ios/Plugin/CameraController.swift
+++ b/ios/Plugin/CameraController.swift
@@ -39,7 +39,7 @@ class CameraController: NSObject {
 }
 
 extension CameraController {
-    func prepare(cameraPosition: String, completionHandler: @escaping (Error?) -> Void) {
+    func prepare(cameraPosition: String, disableAudio: Bool, completionHandler: @escaping (Error?) -> Void) {
         func createCaptureSession() {
             self.captureSession = AVCaptureSession()
         }
@@ -64,7 +64,9 @@ extension CameraController {
                     camera.unlockForConfiguration()
                 }
             }
-            self.audioDevice = AVCaptureDevice.default(for: AVMediaType.audio)
+            if !disableAudio {
+                self.audioDevice = AVCaptureDevice.default(for: AVMediaType.audio)
+            }
         }
 
         func configureDeviceInputs() throws {
@@ -90,12 +92,14 @@ extension CameraController {
             } else { throw CameraControllerError.noCamerasAvailable }
 
             // Add audio input
-            if let audioDevice = self.audioDevice {
-                self.audioInput = try AVCaptureDeviceInput(device: audioDevice)
-                if captureSession.canAddInput(self.audioInput!) {
-                    captureSession.addInput(self.audioInput!)
-                } else {
-                    throw CameraControllerError.inputsAreInvalid
+            if !disableAudio {
+                if let audioDevice = self.audioDevice {
+                    self.audioInput = try AVCaptureDeviceInput(device: audioDevice)
+                    if captureSession.canAddInput(self.audioInput!) {
+                        captureSession.addInput(self.audioInput!)
+                    } else {
+                        throw CameraControllerError.inputsAreInvalid
+                    }
                 }
             }
         }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -21,6 +21,7 @@ public class CameraPreview: CAPPlugin {
     var storeToFile: Bool?
     var enableZoom: Bool?
     var highResolutionOutput: Bool = false
+    var disableAudio: Bool = false
 
     @objc func rotated() {
 
@@ -59,6 +60,7 @@ public class CameraPreview: CAPPlugin {
         self.cameraPosition = call.getString("position") ?? "rear"
         self.highResolutionOutput = call.getBool("enableHighResolution") ?? false
         self.cameraController.highResolutionOutput = self.highResolutionOutput;
+        self.disableAudio = call.getBool("disableAudio") ?? false
 
         if call.getInt("width") != nil {
             self.width = CGFloat(call.getInt("width")!)
@@ -91,7 +93,7 @@ public class CameraPreview: CAPPlugin {
                 if (self.cameraController.captureSession?.isRunning ?? false) {
                     call.reject("camera already started")
                 } else {
-                    self.cameraController.prepare(cameraPosition: self.cameraPosition){error in
+                    self.cameraController.prepare(cameraPosition: self.cameraPosition, disableAudio: self.disableAudio){error in
                         if let error = error {
                             print(error)
                             call.reject(error.localizedDescription)

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -60,7 +60,6 @@ public class CameraPreview: CAPPlugin {
         self.cameraPosition = call.getString("position") ?? "rear"
         self.highResolutionOutput = call.getBool("enableHighResolution") ?? false
         self.cameraController.highResolutionOutput = self.highResolutionOutput;
-        self.disableAudio = call.getBool("disableAudio") ?? false
 
         if call.getInt("width") != nil {
             self.width = CGFloat(call.getInt("width")!)
@@ -82,7 +81,8 @@ public class CameraPreview: CAPPlugin {
         self.toBack = call.getBool("toBack") ?? false
         self.storeToFile = call.getBool("storeToFile") ?? false
         self.enableZoom = call.getBool("enableZoom") ?? false
-
+        self.disableAudio = call.getBool("disableAudio") ?? false
+		
         AVCaptureDevice.requestAccess(for: .video, completionHandler: { (granted: Bool) in
             guard granted else {
                 call.reject("permission failed");


### PR DESCRIPTION
Fixes issue #191 by disabling audio on iOS, if the `disableAudio` option is enabled. Therefore the `NSMicrophoneUsageDescription` permission is optional now.