### PR TITLE
Fix wrong return type on `flip` and `setFlashMode`

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -64,7 +64,7 @@ export interface CameraPreviewPlugin {
   getSupportedFlashModes(): Promise<{
     result: CameraPreviewFlashMode[];
   }>;
-  setFlashMode(options: { flashMode: CameraPreviewFlashMode | string }): void;
-  flip(): void;
+  setFlashMode(options: { flashMode: CameraPreviewFlashMode | string }): Promise<void>;
+  flip(): Promise<void>;
   setOpacity(options: CameraOpacityOptions): Promise<{}>;
 }


### PR DESCRIPTION
`flip` and `setFlashMode` are defined as returning `void`, which is not correct. These methods (like all others) return a `Promise`. The wrong return type makes it impossible to catch any errors from these methods without an unsafe cast (`as unknown as Promise<void>`)