### PR TITLE
Adding .autoExpose during prepare.

### DIFF
--- a/ios/Plugin/CameraController.swift
+++ b/ios/Plugin/CameraController.swift
@@ -61,6 +61,7 @@ extension CameraController {
 
                     try camera.lockForConfiguration()
                     camera.focusMode = .continuousAutoFocus
+                    camera.exposureMode = .autoExpose
                     camera.unlockForConfiguration()
                 }
             }


### PR DESCRIPTION
If we specify the exposure mode during prepare the camera will not get blurry as a user moves the camera around. Thus they won't have to tap on the camera.