### PR TITLE
always assign new value to camera property

### DIFF
--- a/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/Preview.java
@@ -62,8 +62,9 @@ class Preview extends RelativeLayout implements SurfaceHolder.Callback, TextureV
     }
 
     public void setCamera(Camera camera, int cameraId) {
+        mCamera = camera;
+
         if (camera != null) {
-            mCamera = camera;
             this.cameraId = cameraId;
             mSupportedPreviewSizes = mCamera.getParameters().getSupportedPreviewSizes();
             setCameraDisplayOrientation();


### PR DESCRIPTION
`setCamera` gets called with `null` when camera is released. Caused some crashes because it didn't propagate to `Preview`