### PR TITLE
fix for java.lang.NullPointerException in setupBroadcast() func

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 
-  <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      >
+  <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   </manifest>
   

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -487,7 +487,7 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
                 new View.OnTouchListener() {
                     @Override
                     public boolean onTouch(View v, MotionEvent event) {
-                        if ((null != fragment) && (fragment.toBack == true)) {
+                        if ((fragment != null) && (fragment.toBack == true) && (fragment.frameContainerLayout != null)) {
                             fragment.frameContainerLayout.dispatchTouchEvent(event);
                         }
                         return false;


### PR DESCRIPTION
fix for
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.widget.FrameLayout.dispatchTouchEvent(android.view.MotionEvent)' on a null object reference
       at com.ahm.capacitor.camera.preview.CameraPreview$4.onTouch(CameraPreview.java:500)