### PR TITLE
fix: Android audio permissions request

### DIFF
--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -1,6 +1,7 @@
 package com.ahm.capacitor.camera.preview;
 
 import static android.Manifest.permission.CAMERA;
+import static android.Manifest.permission.RECORD_AUDIO;
 
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
@@ -28,7 +29,7 @@ import java.io.File;
 import java.util.List;
 import org.json.JSONArray;
 
-@CapacitorPlugin(name = "CameraPreview", permissions = { @Permission(strings = { CAMERA }, alias = CameraPreview.CAMERA_PERMISSION_ALIAS) })
+@CapacitorPlugin(name = "CameraPreview", permissions = { @Permission(strings = { CAMERA, RECORD_AUDIO }, alias = CameraPreview.CAMERA_PERMISSION_ALIAS) })
 public class CameraPreview extends Plugin implements CameraActivity.CameraPreviewListener {
 
     static final String CAMERA_PERMISSION_ALIAS = "camera";


### PR DESCRIPTION
This fixes a bug where the user is not prompted for permission to record audio on Android, which resulted in poor user experience if not a crash.

Several others have experienced this bug in addition to me:

https://github.com/capacitor-community/camera-preview/issues/309#issuecomment-1708524347
https://github.com/capacitor-community/camera-preview/issues/314#issue-1889157888
https://github.com/capacitor-community/camera-preview/issues/310#issue-1842528184