### PR TITLE
adding ability to preserve WebView's opacity when stop() is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,12 @@ Ex: VueJS >> App.vue component
 ```
 
 
-### stop()
+### stop(options)
+
+| Option          | values        | descriptions                                                                                                              |
+|-----------------|---------------|---------------------------------------------------------------------------------------------------------------------------|
+| backgroundColor | number        | (optional) Android only. Background color for WebView. Set to 0 to keep TRANSPARENT background. Default -1 (Color.WHITE). |
+
 
 <info>Stops the camera preview instance.</info><br/>
 

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -110,6 +110,7 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
 
     @PluginMethod
     public void stop(final PluginCall call) {
+        final Integer backgroundColor = call.getInt("backgroundColor", Color.WHITE);
         bridge
             .getActivity()
             .runOnUiThread(
@@ -123,7 +124,7 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
 
                         if (containerView != null) {
                             ((ViewGroup) getBridge().getWebView().getParent()).removeView(containerView);
-                            getBridge().getWebView().setBackgroundColor(Color.WHITE);
+                            getBridge().getWebView().setBackgroundColor(backgroundColor == null ? Color.WHITE : backgroundColor);
                             FragmentManager fragmentManager = getActivity().getFragmentManager();
                             FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
                             fragmentTransaction.remove(fragment);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -22,6 +22,9 @@ public class CameraPreview: CAPPlugin {
     var enableZoom: Bool?
     var highResolutionOutput: Bool = false
     var disableAudio: Bool = false
+    var originalOpacity: Bool?
+    var originalBackgroundColor: UIColor?
+    var originalScrollbarBgColor: UIColor?
 
     @objc func rotated() {
         let height = self.paddingBottom != nil ? self.height! - self.paddingBottom!: self.height!
@@ -86,8 +89,11 @@ public class CameraPreview: CAPPlugin {
                         }
                         let height = self.paddingBottom != nil ? self.height! - self.paddingBottom!: self.height!
                         self.previewView = UIView(frame: CGRect(x: self.x ?? 0, y: self.y ?? 0, width: self.width!, height: height))
+                        self.originalOpacity = self.webView?.isOpaque
                         self.webView?.isOpaque = false
+                        self.originalBackgroundColor = self.webView?.backgroundColor
                         self.webView?.backgroundColor = UIColor.clear
+                        self.originalScrollbarBgColor = self.webView?.scrollView.backgroundColor
                         self.webView?.scrollView.backgroundColor = UIColor.clear
                         self.webView?.superview?.addSubview(self.previewView)
                         if self.toBack! {
@@ -125,7 +131,9 @@ public class CameraPreview: CAPPlugin {
             if self.cameraController.captureSession?.isRunning ?? false {
                 self.cameraController.captureSession?.stopRunning()
                 self.previewView.removeFromSuperview()
-                self.webView?.isOpaque = true
+                self.webView?.isOpaque = self.originalOpacity!
+                self.webView?.backgroundColor = self.originalBackgroundColor!
+                self.webView?.scrollView.backgroundColor = self.originalScrollbarBgColor!
                 call.resolve()
             } else {
                 call.reject("camera already stopped")

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -51,6 +51,11 @@ export interface CameraSampleOptions {
   quality?: number;
 }
 
+export interface CameraPreviewStopOptions {
+  /** Android only. Defaults to -1 (Color.WHITE). Set to 0 if you want to keep transparent background */
+  backgroundColor?: number;
+}
+
 export type CameraPreviewFlashMode = 'off' | 'on' | 'auto' | 'red-eye' | 'torch';
 
 export interface CameraOpacityOptions {
@@ -61,7 +66,7 @@ export interface CameraOpacityOptions {
 export interface CameraPreviewPlugin {
   start(options: CameraPreviewOptions): Promise<{}>;
   startRecordVideo(options: CameraPreviewOptions): Promise<{}>;
-  stop(): Promise<{}>;
+  stop(options: CameraPreviewStopOptions): Promise<{}>;
   stopRecordVideo(): Promise<{}>;
   capture(options: CameraPreviewPictureOptions): Promise<{ value: string }>;
   captureSample(options: CameraSampleOptions): Promise<{ value: string }>;


### PR DESCRIPTION
Android: you can call stop with optional parameter to set WebView's background color
iOS: opacity is now preserved during start call and restored when stop is called