### PR TITLE
feat: Add high resolution support for camera picture taking

### DIFF
--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -279,6 +279,7 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
         final Boolean enableZoom = call.getBoolean("enableZoom", false);
         final Boolean disableExifHeaderStripping = call.getBoolean("disableExifHeaderStripping", true);
         final Boolean lockOrientation = call.getBoolean("lockAndroidOrientation", false);
+        final Boolean enableHighResolution = call.getBoolean("enableHighResolution", false);
         previousOrientationRequest = getBridge().getActivity().getRequestedOrientation();
 
         fragment = new CameraActivity();
@@ -292,6 +293,7 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
         fragment.toBack = toBack;
         fragment.enableOpacity = enableOpacity;
         fragment.enableZoom = enableZoom;
+        fragment.enableHighResolution = enableHighResolution;
 
         bridge
             .getActivity()


### PR DESCRIPTION
- Introduced `enableHighResolution` flag in `CameraActivity` and `CameraPreview` to allow users to capture images in higher resolutions.
- Updated logic in `getOptimalPictureSize` to select the highest resolution available when no specific dimensions are requested and high resolution is enabled.
- Enhanced `takePicture` method to handle high resolution scenarios and log the selected resolution.


Feature Request For:
#325 