### PR TITLE
Use photo preset to remove excess zoom on ios 17+

### DIFF
--- a/ios/Plugin/CameraController.swift
+++ b/ios/Plugin/CameraController.swift
@@ -41,7 +41,11 @@ class CameraController: NSObject {
 extension CameraController {
     func prepare(cameraPosition: String, disableAudio: Bool, completionHandler: @escaping (Error?) -> Void) {
         func createCaptureSession() {
-            self.captureSession = AVCaptureSession()
+            let captureSession = AVCaptureSession()
+            if captureSession.canSetSessionPreset(AVCaptureSession.Preset.photo) {
+              captureSession.sessionPreset = AVCaptureSession.Preset.photo
+            }
+            self.captureSession = captureSession
         }
 
         func configureCaptureDevices() throws {


### PR DESCRIPTION
### Summary: ###
Fixes issue where iOS 17 & 18, CameraPreview.start {
position: rear,
disableAudio: true,
enableHighResolution: false
}, with no use of any CameraPreview.setZoom, was showing a more zoomed in feed than the native Camera app did.

### Task Links: ###
PR #339 
Issue #180  

### Test Instructions: ###
Place iOS device on a stack of books overlooking a computer keyboard, to keep an identical device position.
Use the native Camera app to take a photo of the keyboard.
Create code that shows the prior photo with partial transparency over the fullscreen CameraPreview.start feed.
Verify that the preview feed matches the scale of the key outlines and lettering in the reference photo.

### Developer Notes: ###
I tested my solution on an iPhone 12 Pro iOS18.3 (which has multiple rear cameras) and an iPad (no notch, only has one rear camera) iOS 17, and the fix showed correctly on both.
Some clients with unknown models of iPhone iOS18.3 still were showing incorrectly with this fix, so in considering the referenced aspect ratio fix, my two devices were still correct with the suggested aspect ratio fix in place, haven't tested if it helps them.
