### PR TITLE
Fix NullPointerException in setupBroadcast when frameContainerLayout is null (Fixes #274)

### DIFF
--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -480,7 +480,7 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
                 new View.OnTouchListener() {
                     @Override
                     public boolean onTouch(View v, MotionEvent event) {
-                        if ((null != fragment) && (fragment.toBack == true)) {
+                        if ((null != fragment) && (null != fragment.frameContainerLayout) && (fragment.toBack == true)) {
                             fragment.frameContainerLayout.dispatchTouchEvent(event);
                         }
                         return false;


### PR DESCRIPTION
Hello,
I have tested the change proposed on #274 to resolve this issue and it worked.
Let me know if anything else is needed in this PR.
From the bug description itself:

> Describe the bug
> NullPointerException for Android when "toBack" is set to true.
> 
> NullPointerException: Attempt to invoke virtual method 'boolean android.widget.FrameLayout.dispatchTouchEvent(android.view.MotionEvent)' on a null object reference
> 
> To Reproduce
> Steps to reproduce the behavior:
> 
> Integrate this plugin
> Set "toBack" to true
> Running app
> When opening a screen that is invoking start of camera preview and user immediately clicks on screen when camera is not finished launching, app crashes
> Expected behavior
> 
> App does not crash when clicking to early on screen..
> 
> Additional context
> 
> In the CameraPreview -> setupBroadcast method we invoke fragment.frameContainerLayout.dispatchTouchEvent(event);
> This will crash when fragment.frameContainerLayout is null. This is not being checked accordingly. Please, check the current method below.
> 
> I think, there should be (null != fragment.frameContainerLayout) added to the if statement.

```

private void setupBroadcast() {
        /** When touch event is triggered, relay it to camera view if needed so it can support pinch zoom */

        getBridge().getWebView().setClickable(true);
        getBridge()
            .getWebView()
            .setOnTouchListener(
                new View.OnTouchListener() {
                    @Override
                    public boolean onTouch(View v, MotionEvent event) {
                        if ((null != fragment) && (fragment.toBack == true)) {
                            fragment.frameContainerLayout.dispatchTouchEvent(event);
                        }
                        return false;
                    }
                }
            );
    }
```